### PR TITLE
fixes #64

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,13 @@
+# Akka Persistence Mongo Releases #
+
+### Version 0.7.3-SNAPSHOT ###
+
+Upgrade to AKKA 2.3.4
+
+Deprecated CasbahJournal.writeConfirmations
+
+Deprecated CasbahJournal.deleteMessages
+
+* [Pull 65](https://github.com/ddevore/akka-persistence-mongo/pull/65) Upgrade to AKKA 2.3.4
+
+

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The mongo journal driver is now available on the Maven Central Snapshot Repo.
     resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
     libraryDependencies ++= Seq(
-      "com.github.ddevore" %% "akka-persistence-mongo-casbah"  % "0.7.2-SNAPSHOT" % "compile")
+      "com.github.ddevore" %% "akka-persistence-mongo-casbah"  % "0.7.3-SNAPSHOT" % "compile")
 
 ### Maven
 
@@ -30,7 +30,7 @@ The mongo journal driver is now available on the Maven Central Snapshot Repo.
     <dependency>
         <groupId>com.github.ddevore</groupId>
         <artifactId>akka-persistence-mongo-casbah_2.10</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.3-SNAPSHOT</version>
     </dependency>
 
 #### Scala 2.11.0
@@ -38,14 +38,14 @@ The mongo journal driver is now available on the Maven Central Snapshot Repo.
     <dependency>
         <groupId>com.github.ddevore</groupId>
         <artifactId>akka-persistence-mongo-casbah_2.11</artifactId>
-        <version>0.7.2-SNAPSHOT</version>
+        <version>0.7.3-SNAPSHOT</version>
     </dependency>
 
 ### Build Locally
 
 Build and install the journal plugin to your local Ivy cache with `sbt publishLocal` (requires sbt 0.13.2). It can then be included as dependency:
 
-    libraryDependencies += "com.github.ddevore" %% "akka-persistence-mongo-casbah" % "0.7.2-SNAPSHOT"
+    libraryDependencies += "com.github.ddevore" %% "akka-persistence-mongo-casbah" % "0.7.3-SNAPSHOT"
 
 ## Journal Configuration
 
@@ -109,7 +109,7 @@ This is an `Int` value that sets the timeout for the snapshot-store write concer
 
 ### casbah.snapshot.mongo-snapshot-load-attempts
 
-Allows for the selection of the youngest of `{n}` snapshots that the match upper bound. This helps where a snapshot may not have persisted correctly because of a JVM crash. As a result an attempt to load the snapshot may fail but an older may succeed. This is an `Int` value that defaults to 3.
+Allows for the selection of the youngest of `{n}` snapshots that match the upper bound. This helps where a snapshot may not have persisted correctly because of a JVM crash. As a result an attempt to load the snapshot may fail but an older may succeed. This is an `Int` value that defaults to 3.
 
 ## Status
 
@@ -118,14 +118,17 @@ Allows for the selection of the youngest of `{n}` snapshots that the match upper
 - When using channels, confirmation writes are batched to optimize throughput.
 - Deletes (marked & permanent) are batched to optimize throughput.
 - Sharding is not yet supported.
-- Akka-Persistence is still considered **experimental** as such the underlying api may change based on user feedback.
+- Akka-Persistence is still considered **experimental** and as such the underlying api may change based on changes to Akka Persistence or user feedback.
 
 ## Performance
 
 Minimal performance testing is included against a **native** instance. In general the journal will persist around 7000 to 8000 messages per second.
 
 ## Example
-We now have an [example application](https://github.com/ddevore/akka-persistence-mongo/tree/master/akka-persistence-mongo-command-sourcing-example-app) that implements Akka-Persistence [command sourcing](http://doc.akka.io/docs/akka/2.3.0/scala/persistence.html#Processors). In this example, the journal acts as a write-ahead-log for whatever `Persistent` messages it recieves. In the future, we will add an application example that implements Akka-Persistence [event sourcing](http://doc.akka.io/docs/akka/2.3.0/scala/persistence.html#Event_sourcing).
+There is an [example application](https://github.com/ddevore/akka-persistence-mongo/tree/master/akka-persistence-mongo-command-sourcing-example-app) that implements Akka-Persistence [command sourcing](http://doc.akka.io/docs/akka/2.3.0/scala/persistence.html#Processors). In this example, the journal acts as a write-ahead-log for whatever persisted messages it recieves. 
+
+There is also an [example application](https://github.com/ddevore/akka-persistence-mongo/tree/master/akka-persistence-mongo-event-sourcing-example-app) that implements Akka-Persistence [event sourcing](http://doc.akka.io/docs/akka/2.3.0/scala/persistence.html#Event_sourcing).
+
 
 ## Author / Maintainer
 

--- a/akka-persistence-mongo-casbah/build.sbt
+++ b/akka-persistence-mongo-casbah/build.sbt
@@ -27,5 +27,5 @@ resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositor
 
 libraryDependencies ++= Seq(
   "org.mongodb"         %% "casbah"                        % "2.7.1"              % "compile",
-  "com.github.krasserm" %% "akka-persistence-testkit"      % "0.3.1"              % "test"
+  "com.github.krasserm" %% "akka-persistence-testkit"      % "0.3.3"              % "test"
 )

--- a/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/journal/CasbahJournalHelper.scala
+++ b/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/journal/CasbahJournalHelper.scala
@@ -11,7 +11,7 @@ import akka.persistence.mongo.MongoPersistenceJournalRoot
 
 private[mongo] trait CasbahJournalHelper extends MongoPersistenceJournalRoot {
 
-  val ProcessorIdKey = "processorId"
+  val PersistenceIdKey = "persistenceId"
   val SequenceNrKey = "sequenceNr"
   val AggIdKey = "_id"
   val AddDetailsKey = "details"
@@ -25,7 +25,7 @@ private[mongo] trait CasbahJournalHelper extends MongoPersistenceJournalRoot {
   val MarkerDelete = "D"
 
   private[this] val idx1 = MongoDBObject(
-    "processorId"         -> 1,
+    "persistenceId"         -> 1,
     "sequenceNr"          -> 1,
     "marker"              -> 1)
 
@@ -33,7 +33,7 @@ private[mongo] trait CasbahJournalHelper extends MongoPersistenceJournalRoot {
     MongoDBObject("unique" -> true)
 
   private[this] val idx2 = MongoDBObject(
-    "processorId"         -> 1,
+    "persistenceId"         -> 1,
     "sequenceNr"          -> 1)
 
   private[this] val idx3 =
@@ -50,7 +50,7 @@ private[mongo] trait CasbahJournalHelper extends MongoPersistenceJournalRoot {
 
   def writeJSON(pId: String, sNr: Long, pr: PersistentRepr) = {
     val builder = MongoDBObject.newBuilder
-    builder += ProcessorIdKey -> pId
+    builder += PersistenceIdKey -> pId
     builder += SequenceNrKey  -> sNr
     builder += MarkerKey      -> MarkerAccepted
     builder += MessageKey     -> toBytes(pr)
@@ -59,7 +59,7 @@ private[mongo] trait CasbahJournalHelper extends MongoPersistenceJournalRoot {
 
   def confirmJSON(pId: String, sNr: Long, cId: String) = {
     val builder = MongoDBObject.newBuilder
-    builder += ProcessorIdKey -> pId
+    builder += PersistenceIdKey -> pId
     builder += SequenceNrKey  -> sNr
     builder += MarkerKey      -> markerConfirm(cId)
     builder += MessageKey     -> Array.empty[Byte]
@@ -68,36 +68,36 @@ private[mongo] trait CasbahJournalHelper extends MongoPersistenceJournalRoot {
 
   def deleteMarkJSON(pId: String, sNr: Long) = {
     val builder = MongoDBObject.newBuilder
-    builder += ProcessorIdKey -> pId
+    builder += PersistenceIdKey -> pId
     builder += SequenceNrKey  -> sNr
     builder += MarkerKey      -> MarkerDelete
     builder += MessageKey     -> Array.empty[Byte]
     builder.result()
   }
 
-  def delStatement(processorId: String, sequenceNr: Long): MongoDBObject =
-    MongoDBObject(ProcessorIdKey -> processorId, SequenceNrKey -> sequenceNr)
+  def delStatement(persistenceId: String, sequenceNr: Long): MongoDBObject =
+    MongoDBObject(PersistenceIdKey -> persistenceId, SequenceNrKey -> sequenceNr)
 
-  def delToStatement(processorId: String, toSequenceNr: Long): MongoDBObject =
+  def delToStatement(persistenceId: String, toSequenceNr: Long): MongoDBObject =
     MongoDBObject(
-      ProcessorIdKey -> processorId,
+      PersistenceIdKey -> persistenceId,
       SequenceNrKey  -> MongoDBObject("$lte" -> toSequenceNr))
 
   def delOrStatement(elements: List[MongoDBObject]): MongoDBObject =
     MongoDBObject("$or" -> elements)
 
-  def replayFindStatement(processorId: String, fromSequenceNr: Long, toSequenceNr: Long): MongoDBObject =
+  def replayFindStatement(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): MongoDBObject =
     MongoDBObject(
-      ProcessorIdKey -> processorId,
+      PersistenceIdKey -> persistenceId,
       SequenceNrKey  -> MongoDBObject("$gte" -> fromSequenceNr, "$lte" -> toSequenceNr))
 
   def recoverySortStatement = MongoDBObject(
-    "processorId" -> 1,
+    "persistenceId" -> 1,
     "sequenceNr"  -> 1,
     "marker"      -> 1)
 
-  def snrQueryStatement(processorId: String): MongoDBObject =
-    MongoDBObject(ProcessorIdKey -> processorId)
+  def snrQueryStatement(persistenceId: String): MongoDBObject =
+    MongoDBObject(PersistenceIdKey -> persistenceId)
 
   def maxSnrSortStatement: MongoDBObject =
     MongoDBObject(SequenceNrKey -> -1)

--- a/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/snapshot/CasbahSnapshotHelper.scala
+++ b/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/snapshot/CasbahSnapshotHelper.scala
@@ -11,13 +11,13 @@ import com.mongodb.casbah.Imports._
 
 private[mongo] trait CasbahSnapshotHelper extends MongoPersistenceSnapshotRoot {
 
-  val ProcessorIdKey = "processorId"
+  val PersistenceIdKey = "persistenceId"
   val SequenceNrKey = "sequenceNr"
   val TimestampKey = "timestamp"
   val SnapshotKey = "snapshot"
 
   private[this] val snapIdx1 = MongoDBObject(
-    "processorId"         -> 1,
+    "persistenceId"       -> 1,
     "sequenceNr"          -> 1,
     "timestamp"           -> 1)
 
@@ -33,7 +33,7 @@ private[mongo] trait CasbahSnapshotHelper extends MongoPersistenceSnapshotRoot {
 
   def writeJSON(snapshot: SelectedSnapshot) = {
     val builder = MongoDBObject.newBuilder
-    builder += ProcessorIdKey -> snapshot.metadata.processorId
+    builder += PersistenceIdKey -> snapshot.metadata.persistenceId
     builder += SequenceNrKey  -> snapshot.metadata.sequenceNr
     builder += TimestampKey   -> snapshot.metadata.timestamp
     builder += SnapshotKey    -> toBytes(snapshot)
@@ -41,20 +41,20 @@ private[mongo] trait CasbahSnapshotHelper extends MongoPersistenceSnapshotRoot {
   }
 
   def delStatement(meta: SnapshotMetadata): MongoDBObject =
-    MongoDBObject(ProcessorIdKey -> meta.processorId, SequenceNrKey -> meta.sequenceNr, TimestampKey -> meta.timestamp)
+    MongoDBObject(PersistenceIdKey -> meta.persistenceId, SequenceNrKey -> meta.sequenceNr, TimestampKey -> meta.timestamp)
 
-  def delStatement(processorId: String, criteria: SnapshotSelectionCriteria): MongoDBObject =
-    maxSnrMaxTimeQueryStatement(processorId, criteria)
+  def delStatement(persistenceId: String, criteria: SnapshotSelectionCriteria): MongoDBObject =
+    maxSnrMaxTimeQueryStatement(persistenceId, criteria)
 
-  def snapshotsQueryStatement(processorId: String, criteria: SnapshotSelectionCriteria): MongoDBObject =
-    maxSnrMaxTimeQueryStatement(processorId, criteria)
+  def snapshotsQueryStatement(persistenceId: String, criteria: SnapshotSelectionCriteria): MongoDBObject =
+    maxSnrMaxTimeQueryStatement(persistenceId, criteria)
 
   def snapshotsSortStatement: MongoDBObject =
     MongoDBObject(SequenceNrKey -> -1, TimestampKey -> -1)
 
-  private def maxSnrMaxTimeQueryStatement(processorId: String, criteria: SnapshotSelectionCriteria): MongoDBObject =
+  private def maxSnrMaxTimeQueryStatement(persistenceId: String, criteria: SnapshotSelectionCriteria): MongoDBObject =
     MongoDBObject(
-      ProcessorIdKey -> processorId,
+      PersistenceIdKey -> persistenceId,
       SequenceNrKey  -> MongoDBObject("$lte" -> criteria.maxSequenceNr),
       TimestampKey   -> MongoDBObject("$lte" -> criteria.maxTimestamp)
     )

--- a/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/snapshot/CasbahSnapshotStore.scala
+++ b/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/snapshot/CasbahSnapshotStore.scala
@@ -31,8 +31,8 @@ private[persistence] class CasbahSnapshotStore  extends SnapshotStore
   /** Snapshots we're in progress of saving */
   private var saving = immutable.Set.empty[SnapshotMetadata]
 
-  override def delete(processorId: String, criteria: SnapshotSelectionCriteria): Unit =
-    collection.remove(delStatement(processorId, criteria))
+  override def delete(persistenceId: String, criteria: SnapshotSelectionCriteria): Unit =
+    collection.remove(delStatement(persistenceId, criteria))
 
   override def delete(metadata: SnapshotMetadata): Unit = {
     saving -= metadata
@@ -47,12 +47,12 @@ private[persistence] class CasbahSnapshotStore  extends SnapshotStore
     Future(collection.insert(writeJSON(SelectedSnapshot(metadata, snapshot))))
   }
 
-  override def loadAsync(processorId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
+  override def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
     // Select the youngest of {n} snapshots that match the upper bound. This helps where a snapshot may not have
     // persisted correctly because of a JVM crash. As a result an attempt to load the snapshot may fail but an older
     // may succeed.
     Future {
-      val snaps = collection.find(snapshotsQueryStatement(processorId, criteria))
+      val snaps = collection.find(snapshotsQueryStatement(persistenceId, criteria))
         .sort(snapshotsSortStatement)
         .limit(configMongoSnapshotLoadAttempts)
       load(snaps.to[immutable.Seq])

--- a/akka-persistence-mongo-casbah/src/test/scala/akka/persistence/mongo/journal/CasbahJournalSpec.scala
+++ b/akka-persistence-mongo-casbah/src/test/scala/akka/persistence/mongo/journal/CasbahJournalSpec.scala
@@ -1,6 +1,6 @@
 /**
- *  Copyright (C) 2013-2014 Duncan DeVore. <http://reactant.org>
- */
+*  Copyright (C) 2013-2014 Duncan DeVore. <http://reactant.org>
+*/
 package akka.persistence.mongo.journal
 
 import akka.persistence.journal.JournalSpec

--- a/akka-persistence-mongo-casbah/src/test/scala/akka/persistence/mongo/snapshot/CasbahSnapshotSpec.scala
+++ b/akka-persistence-mongo-casbah/src/test/scala/akka/persistence/mongo/snapshot/CasbahSnapshotSpec.scala
@@ -1,6 +1,6 @@
 /**
- *  Copyright (C) 2013-2014 Duncan DeVore. <http://reactant.org>
- */
+*  Copyright (C) 2013-2014 Duncan DeVore. <http://reactant.org>
+*/
 package akka.persistence.mongo.snapshot
 
 import akka.persistence.mongo.MongoCleanup

--- a/akka-persistence-mongo-command-sourcing-example-app/build.sbt
+++ b/akka-persistence-mongo-command-sourcing-example-app/build.sbt
@@ -19,13 +19,13 @@ publishArtifact := false
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka"      %% "akka-persistence-experimental" % "2.3.2"            % "compile",
-  "com.github.ddevore"     %% "akka-persistence-mongo-casbah" % "0.7.2-SNAPSHOT"   % "compile",
+  "com.typesafe.akka"      %% "akka-persistence-experimental" % "2.3.4"            % "compile",
+  "com.github.ddevore"     %% "akka-persistence-mongo-casbah" % Common.Version     % "compile",
   "org.scalaz"             %% "scalaz-core"                   % "7.0.6"            % "compile",
   "com.novus"              %% "salat"                         % "1.9.8"            % "compile",
   "org.scala-stm"          %% "scala-stm"                     % "0.7"              % "compile",
-  "com.typesafe.akka"      %% "akka-slf4j"                    % "2.3.2"            % "compile",
-  "com.typesafe.akka"      %% "akka-testkit"                  % "2.3.2"            % "test",
+  "com.typesafe.akka"      %% "akka-slf4j"                    % "2.3.4"            % "compile",
+  "com.typesafe.akka"      %% "akka-testkit"                  % "2.3.4"            % "test",
   "de.flapdoodle.embed"     % "de.flapdoodle.embed.mongo"     % "1.43"             % "test",
   "org.scalatest"          %% "scalatest"                     % "2.1.3"            % "test"
 )

--- a/akka-persistence-mongo-command-sourcing-example-app/src/main/scala/org/example/Confirmations.scala
+++ b/akka-persistence-mongo-command-sourcing-example-app/src/main/scala/org/example/Confirmations.scala
@@ -1,0 +1,10 @@
+package org.example
+
+import akka.persistence.SnapshotMetadata
+
+/**
+ * Common messages dispatched to the event stream for probing in tests
+ */
+sealed trait Confirmations
+case class MsgConfirmed(deliveryId: Long) extends Confirmations
+case class SnapshotConfirmed(snap: SnapshotMetadata) extends Confirmations

--- a/akka-persistence-mongo-command-sourcing-example-app/src/main/scala/org/example/Messages.scala
+++ b/akka-persistence-mongo-command-sourcing-example-app/src/main/scala/org/example/Messages.scala
@@ -1,0 +1,9 @@
+package org.example
+
+/**
+ * common messages used in testing
+ */
+case class Msg(deliveryId: Long, payload: Any)
+case class Confirm(deliveryId: Long)
+
+

--- a/akka-persistence-mongo-common/build.sbt
+++ b/akka-persistence-mongo-common/build.sbt
@@ -24,8 +24,8 @@ pomExtra := Common.PomXtra
 libraryDependencies ++= Seq(
   "ch.qos.logback"       % "logback-classic"                % "1.1.1"     % "compile",
   "commons-io"           % "commons-io"                     % "2.4"       % "test",
-  "com.typesafe.akka"   %% "akka-testkit"                   % "2.3.2"     % "test",
-  "com.typesafe.akka"   %% "akka-persistence-experimental"  % "2.3.2"     % "compile",
+  "com.typesafe.akka"   %% "akka-testkit"                   % "2.3.4"     % "test",
+  "com.typesafe.akka"   %% "akka-persistence-experimental"  % "2.3.4"     % "compile",
   "de.flapdoodle.embed"  % "de.flapdoodle.embed.mongo"      % "1.43"      % "test",
   "org.scalatest"       %% "scalatest"                      % "2.1.3"     % "test"
 )

--- a/akka-persistence-mongo-event-sourcing-example-app/build.sbt
+++ b/akka-persistence-mongo-event-sourcing-example-app/build.sbt
@@ -19,13 +19,13 @@ publishArtifact := false
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka"      %% "akka-persistence-experimental" % "2.3.2"            % "compile",
-  "com.github.ddevore"     %% "akka-persistence-mongo-casbah" % "0.7.2-SNAPSHOT"   % "compile",
+  "com.typesafe.akka"      %% "akka-persistence-experimental" % "2.3.4"            % "compile",
+  "com.github.ddevore"     %% "akka-persistence-mongo-casbah" % Common.Version     % "compile",
   "org.scalaz"             %% "scalaz-core"                   % "7.0.6"            % "compile",
   "com.novus"              %% "salat"                         % "1.9.8"            % "compile",
   "org.scala-stm"          %% "scala-stm"                     % "0.7"              % "compile",
-  "com.typesafe.akka"      %% "akka-slf4j"                    % "2.3.2"            % "compile",
-  "com.typesafe.akka"      %% "akka-testkit"                  % "2.3.2"            % "test",
+  "com.typesafe.akka"      %% "akka-slf4j"                    % "2.3.4"            % "compile",
+  "com.typesafe.akka"      %% "akka-testkit"                  % "2.3.4"            % "test",
   "de.flapdoodle.embed"     % "de.flapdoodle.embed.mongo"     % "1.43"             % "test",
   "org.scalatest"          %% "scalatest"                     % "2.1.3"            % "test"
 )

--- a/akka-persistence-mongo-event-sourcing-example-app/src/main/scala/org/esexample/Benefits.scala
+++ b/akka-persistence-mongo-event-sourcing-example-app/src/main/scala/org/esexample/Benefits.scala
@@ -3,9 +3,6 @@
  */
 package org.esexample
 
-import scala.concurrent.duration._
-
-import akka.actor._
 import akka.persistence._
 
 import com.mongodb.casbah.Imports._
@@ -23,9 +20,8 @@ case class BenefitDates(
   termDates: List[Long],
   rehireDates: List[Long]) extends Benefits
 
-class BenefitsView extends View {
+class BenefitsView extends PersistentView {
   import EmployeeProtocol._
-  import BenefitsProtocol._
   implicit val concern = WriteConcern.JournalSafe
 
   def config = context.system.settings.config.getConfig("benefits-view")
@@ -35,48 +31,46 @@ class BenefitsView extends View {
   private val db = client(uri.database.get)
   private val coll = db(uri.collection.get)
 
-  private val channelName = config.getString("channel")
-
-  override def processorId = "employee-processor"
+  override def persistenceId = "employee-persistence"
   override def viewId = "benefits-view"
 
-  private val destination = context.actorOf(Props[BenefitsDestination])
-  private val channel = context.actorOf(Channel.props(channelName))
-
   def receive = {
-    case p @ Persistent(payload, _) =>
+    case payload if isPersistent =>
+      // Handle journal events
       payload match {
         case evt: EmployeeHired =>
-          val eb = BenefitDates(evt.id, evt.startDate, Nil, Nil, Nil)
-          val dbo = grater[BenefitDates].asDBObject(eb)
-          coll.insert(dbo)
-          channel ! Deliver(p.withPayload(BenefitsHired(evt.startDate, evt.toString)), destination.path)
-        case evt: EmployeeDeactivated =>
-          val dbo = coll.findOne(MongoDBObject("employeeId" -> evt.id)).get
-          val eb = grater[BenefitDates].asObject(dbo)
-          val up = eb.copy(deactivateDates = eb.deactivateDates :+ evt.deactivateDate)
-          coll.update(MongoDBObject("employeeId" -> evt.id), grater[BenefitDates].asDBObject(up))
-          channel ! Deliver(p.withPayload(BenefitsDeactivated(evt.deactivateDate, evt.toString)), destination.path)
-        case evt: EmployeeActivated =>
-          val dbo = coll.findOne(MongoDBObject("employeeId" -> evt.id)).get
-          val eb = grater[BenefitDates].asObject(dbo)
-          val up = eb.copy(startDate = evt.activateDate)
-          coll.update(MongoDBObject("employeeId" -> evt.id), grater[BenefitDates].asDBObject(up))
-          channel ! Deliver(p.withPayload(BenefitsActivated(evt.activateDate, evt.toString)), destination.path)
-        case evt: EmployeeTerminated =>
-          val dbo = coll.findOne(MongoDBObject("employeeId" -> evt.id)).get
-          val eb = grater[BenefitDates].asObject(dbo)
-          val up = eb.copy(termDates = eb.termDates :+ evt.termDate)
-          coll.update(MongoDBObject("employeeId" -> evt.id), grater[BenefitDates].asDBObject(up))
-          channel ! Deliver(p.withPayload(BenefitsTerminated(evt.termDate, evt.toString)), destination.path)
-        case evt: EmployeeRehired =>
-          val dbo = coll.findOne(MongoDBObject("employeeId" -> evt.id)).get
-          val eb = grater[BenefitDates].asObject(dbo)
-          val up = eb.copy(rehireDates = eb.rehireDates :+ evt.rehireDate)
-          coll.update(MongoDBObject("employeeId" -> evt.id), grater[BenefitDates].asDBObject(up))
-          channel ! Deliver(p.withPayload(BenefitsRehired(evt.rehireDate, evt.toString)), destination.path)
-        case _ => // do nothing
+           val eb = BenefitDates(evt.id, evt.startDate, Nil, Nil, Nil)
+           val dbo = grater[BenefitDates].asDBObject(eb)
+           coll.insert(dbo)
+
+         case evt: EmployeeDeactivated =>
+           val dbo = coll.findOne(MongoDBObject("employeeId" -> evt.id)).get
+           val eb = grater[BenefitDates].asObject(dbo)
+           val up = eb.copy(deactivateDates = eb.deactivateDates :+ evt.deactivateDate)
+           coll.update(MongoDBObject("employeeId" -> evt.id), grater[BenefitDates].asDBObject(up))
+
+         case evt: EmployeeActivated =>
+           val dbo = coll.findOne(MongoDBObject("employeeId" -> evt.id)).get
+           val eb = grater[BenefitDates].asObject(dbo)
+           val up = eb.copy(startDate = evt.activateDate)
+           coll.update(MongoDBObject("employeeId" -> evt.id), grater[BenefitDates].asDBObject(up))
+
+         case evt: EmployeeTerminated =>
+           val dbo = coll.findOne(MongoDBObject("employeeId" -> evt.id)).get
+           val eb = grater[BenefitDates].asObject(dbo)
+           val up = eb.copy(termDates = eb.termDates :+ evt.termDate)
+           coll.update(MongoDBObject("employeeId" -> evt.id), grater[BenefitDates].asDBObject(up))
+
+         case evt: EmployeeRehired =>
+           val dbo = coll.findOne(MongoDBObject("employeeId" -> evt.id)).get
+           val eb = grater[BenefitDates].asObject(dbo)
+           val up = eb.copy(rehireDates = eb.rehireDates :+ evt.rehireDate)
+           coll.update(MongoDBObject("employeeId" -> evt.id), grater[BenefitDates].asDBObject(up))
+
+         case _ => // ignore
       }
+    case payload => // Handle user events
+
   }
 
   override def postStop(): Unit = {

--- a/akka-persistence-mongo-event-sourcing-example-app/src/main/scala/org/esexample/BenefitsDestination.scala
+++ b/akka-persistence-mongo-event-sourcing-example-app/src/main/scala/org/esexample/BenefitsDestination.scala
@@ -4,29 +4,25 @@
 package org.esexample
 
 import akka.actor.Actor
-import akka.persistence.ConfirmablePersistent
 
+@deprecated("This is no longer pertinent to the example but may be used in a future example.", since = "0.7.3")
 class BenefitsDestination extends Actor {
 import BenefitsProtocol._
 
   def receive = {
-    case cp @ ConfirmablePersistent(payload, sequenceNr, _) =>
+    case Msg(deliveryId, payload) => {
       payload match {
-        case msg: BenefitsHired =>
-          context.system.eventStream.publish(msg)
-          cp.confirm()
-        case msg: BenefitsDeactivated =>
-          context.system.eventStream.publish(msg)
-          cp.confirm()
-        case msg: BenefitsActivated =>
-          context.system.eventStream.publish(msg)
-          cp.confirm()
-        case msg: BenefitsTerminated =>
-          context.system.eventStream.publish(msg)
-          cp.confirm()
-        case msg: BenefitsRehired =>
-          context.system.eventStream.publish(msg)
-          cp.confirm()
+        case msg: BenefitsHired => handle(deliveryId, msg)
+        case msg: BenefitsDeactivated => handle(deliveryId, msg)
+        case msg: BenefitsActivated => handle(deliveryId, msg)
+        case msg: BenefitsTerminated => handle(deliveryId, msg)
+        case msg: BenefitsRehired => handle(deliveryId, msg)
       }
+    }
+  }
+
+  def handle(deliveryId: Long, benefitsMessage: BenefitsMessage) = {
+    context.system.eventStream.publish(benefitsMessage)
+    sender ! Confirm(deliveryId)
   }
 }

--- a/akka-persistence-mongo-event-sourcing-example-app/src/main/scala/org/esexample/Employee.scala
+++ b/akka-persistence-mongo-event-sourcing-example-app/src/main/scala/org/esexample/Employee.scala
@@ -3,7 +3,7 @@
  */
 package org.esexample
 
-import akka.persistence.{SnapshotOffer, EventsourcedProcessor}
+import akka.persistence.{PersistentActor, SnapshotOffer}
 
 import org.joda.time.{DateTimeZone, DateTime}
 
@@ -212,13 +212,13 @@ final case class EmployeeState(employees: Map[String, Employee] = Map.empty) {
 
 /**
  * The EmployeeProcessor is responsible for maintaining  state changes for all [[Employee]] aggregates. This particular
- * processor uses Akka-Persistence's [[EventsourcedProcessor]]. It receives Commands and if valid will persist the generated events,
+ * processor uses Akka-Persistence's [[PersistentActor]]. It receives Commands and if valid will persist the generated events,
  * afterwhich it will updated the current state of the [[Employee]] being processed.
  */
-class EmployeeProcessor extends EventsourcedProcessor {
+class EmployeeProcessor extends PersistentActor {
   import EmployeeProtocol._
 
-  override def processorId = "employee-processor"
+  override def persistenceId = "employee-persistence"
 
   var state = EmployeeState()
 

--- a/akka-persistence-mongo-event-sourcing-example-app/src/main/scala/org/esexample/Messages.scala
+++ b/akka-persistence-mongo-event-sourcing-example-app/src/main/scala/org/esexample/Messages.scala
@@ -1,0 +1,10 @@
+package org.esexample
+
+/**
+ * common messages used in testing
+ */
+case class Msg(deliveryId: Long, payload: Any)
+
+case class Confirm(deliveryId: Long)
+
+

--- a/akka-persistence-mongo-event-sourcing-example-app/src/test/scala/org/esexample/BenefitsSpec.scala
+++ b/akka-persistence-mongo-event-sourcing-example-app/src/test/scala/org/esexample/BenefitsSpec.scala
@@ -3,7 +3,7 @@
  */
 package org.esexample
 
-import akka.testkit.{TestProbe, ImplicitSender, TestKit}
+import akka.testkit.{ImplicitSender, TestKit}
 import akka.actor.{ActorRef, Props, ActorSystem}
 
 import com.mongodb.casbah.Imports._
@@ -58,7 +58,6 @@ class BenefitsSpec extends TestKit(ActorSystem("test-benefits", BenefitsSpec.con
 
   import BenefitsSpec._
   import EmployeeProtocol._
-  import BenefitsProtocol._
 
   lazy val host = "localhost"
   lazy val port = freePort
@@ -129,8 +128,6 @@ class BenefitsSpec extends TestKit(ActorSystem("test-benefits", BenefitsSpec.con
 
   "The Application" must {
     "when persisted EmployeeHired view persists associated BenefitDates" in {
-      val probe = TestProbe()
-      system.eventStream.subscribe(probe.ref, classOf[BenefitsHired])
       employeeProcessor ! HireEmployee(IdJonSmith, -1l, "smith", "jon", "123 Big Road", "Perkiomenville", "PA", "18074", "USA",
         StartDateMarch1st2014Midnight, "Technology", "The Total Package", BigDecimal(300000))
       val Expected = Some(BenefitDates(IdJonSmith, StartDateMarch1st2014Midnight, Nil, Nil, Nil))
@@ -140,11 +137,8 @@ class BenefitsSpec extends TestKit(ActorSystem("test-benefits", BenefitsSpec.con
         else if (Some(grater[BenefitDates].asObject(dbo.get)) == Expected) true
         else false
       }, duration, 500 milliseconds, "BenefitDates read side failure.")
-      probe.expectMsgType[BenefitsHired](500 millis)
     }
     "when persisted EmployeeDeactivated view persists associated BenefitDates" in {
-      val probe = TestProbe()
-      system.eventStream.subscribe(probe.ref, classOf[BenefitsDeactivated])
       employeeProcessor ! DeactivateEmployee(IdJonSmith, 0L, DeactivateDateMay1st2014Midnight)
       val Expected = Some(BenefitDates(IdJonSmith, StartDateMarch1st2014Midnight, List(DeactivateDateMay1st2014Midnight), Nil, Nil))
       awaitCond({
@@ -153,11 +147,8 @@ class BenefitsSpec extends TestKit(ActorSystem("test-benefits", BenefitsSpec.con
         else if (Some(grater[BenefitDates].asObject(dbo.get)) == Expected) true
         else false
       }, duration, 500 milliseconds, "BenefitDates read side failure.")
-      probe.expectMsgType[BenefitsDeactivated](500 millis)
     }
     "when persisted EmployeeActivated view persists associated BenefitDates" in {
-      val probe = TestProbe()
-      system.eventStream.subscribe(probe.ref, classOf[BenefitsActivated])
       employeeProcessor ! ActivateEmployee(IdJonSmith, 1L, ActivateDateMay2nd2014Midnight)
       val Expected = Some(BenefitDates(IdJonSmith, ActivateDateMay2nd2014Midnight, List(DeactivateDateMay1st2014Midnight), Nil, Nil))
       awaitCond({
@@ -166,11 +157,8 @@ class BenefitsSpec extends TestKit(ActorSystem("test-benefits", BenefitsSpec.con
         else if (Some(grater[BenefitDates].asObject(dbo.get)) == Expected) true
         else false
       }, duration, 500 milliseconds, "BenefitDates read side failure.")
-      probe.expectMsgType[BenefitsActivated](500 millis)
     }
     "when persisted EmployeeTerminated view persists associated BenefitDates" in {
-      val probe = TestProbe()
-      system.eventStream.subscribe(probe.ref, classOf[BenefitsTerminated])
       employeeProcessor ! TerminateEmployee(IdJonSmith, 2L, TerminateDateMay3rd2014Midnight, "Tired")
       val Expected = Some(BenefitDates(IdJonSmith, ActivateDateMay2nd2014Midnight, List(DeactivateDateMay1st2014Midnight),
         List(TerminateDateMay3rd2014Midnight), Nil))
@@ -180,11 +168,8 @@ class BenefitsSpec extends TestKit(ActorSystem("test-benefits", BenefitsSpec.con
         else if (Some(grater[BenefitDates].asObject(dbo.get)) == Expected) true
         else false
       }, duration, 500 milliseconds, "BenefitDates read side failure.")
-      probe.expectMsgType[BenefitsTerminated](500 millis)
     }
     "when persisted EmployeeRehired view persists associated BenefitDates" in {
-      val probe = TestProbe()
-      system.eventStream.subscribe(probe.ref, classOf[BenefitsRehired])
       employeeProcessor ! RehireEmployee(IdJonSmith, 3L, RehireDateMay4th2014Midnight)
       val Expected = Some(BenefitDates(IdJonSmith, ActivateDateMay2nd2014Midnight, List(DeactivateDateMay1st2014Midnight),
         List(TerminateDateMay3rd2014Midnight), List(RehireDateMay4th2014Midnight)))
@@ -194,7 +179,6 @@ class BenefitsSpec extends TestKit(ActorSystem("test-benefits", BenefitsSpec.con
         else if (Some(grater[BenefitDates].asObject(dbo.get)) == Expected) true
         else false
       }, duration, 500 milliseconds, "BenefitDates read side failure.")
-      probe.expectMsgType[BenefitsRehired](500 millis)
     }
   }
 }

--- a/akka-persistence-mongo-event-sourcing-example-app/src/test/scala/org/esexample/EmployeeSpec.scala
+++ b/akka-persistence-mongo-event-sourcing-example-app/src/test/scala/org/esexample/EmployeeSpec.scala
@@ -55,7 +55,6 @@ class EmployeeSpec extends TestKit(ActorSystem("test", EmployeeSpec.config(Emplo
 
   import EmployeeSpec._
   import EmployeeProtocol._
-  import BenefitsProtocol._
 
   lazy val host = "localhost"
   lazy val port = freePort

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -12,8 +12,8 @@ object Common {
   def NameEventSourcingExampleApp = Name + "-event-sourcing-example-app"
   def Organization = "com.github.ddevore"
   def ScalaVersion = "2.11.0"
-  def CrossScalaVersions = Seq("2.10.4", "2.11.0")
-  def Version = "0.7.2-SNAPSHOT"
+  def CrossScalaVersions = Seq("2.10.4", "2.11.1")
+  def Version = "0.7.3-SNAPSHOT"
   def ParallelExecutionInTest = false
   def ScalaCOptions = Seq( "-deprecation", "-unchecked", "-feature", "-language:postfixOps" )
   def TestCompile = "test->test;compile->compile"


### PR DESCRIPTION
-- upgraded to AKKA 2.3.4
-- upgraded journal tests
-- updated build dependencies
-- migrated command sourcing tests to use PersistentActor
-- renamed all references of processorId to persistenceId
-- removed tests for single delete of messages since that method call is deprecated and no longer required.
