### PR TITLE
Serialize Snapshot case class instead of SelectedSnapshot

### DIFF
--- a/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/snapshot/CasbahSnapshotStore.scala
+++ b/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/snapshot/CasbahSnapshotStore.scala
@@ -44,7 +44,7 @@ private[persistence] class CasbahSnapshotStore  extends SnapshotStore
 
   override def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] = {
     saving += metadata
-    Future(collection.insert(writeJSON(SelectedSnapshot(metadata, snapshot))))
+    Future(collection.insert(writeJSON(metadata, snapshot)))
   }
 
   override def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
@@ -63,7 +63,7 @@ private[persistence] class CasbahSnapshotStore  extends SnapshotStore
   private def load(snaps: immutable.Seq[DBObject]): Option[SelectedSnapshot] = snaps.headOption match {
     case None => None
     case Some(snap) =>
-      Try(fromBytes[SelectedSnapshot](snap.as[Array[Byte]](SnapshotKey))) match {
+      readJSON(snap) match {
         case Success(s) => Some(s)
         case Failure(e) =>
           log.error(e, s"error loading snapshot $snap")


### PR DESCRIPTION
There is no serializer registered for SelectedSnapshot, but Akka-Peristence does register a default Protobuf serializer for Snapshot that delegates the payload serialization to the standard Akka serializers.

Without this change an undocumented hack is required (setting a custom serializer for SelectedSnapshot) to use something else then Java serialization for snapshots.
