### PR TITLE
CasbahJournal doesn't survive losted mongo connection

### DIFF
--- a/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/package.scala
+++ b/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/package.scala
@@ -4,9 +4,11 @@
 
 package akka.persistence
 
+import akka.actor.ActorLogging
 import com.mongodb.casbah.Imports._
 
 import scala.language.implicitConversions
+import scala.util.Try
 
 package object mongo {
 
@@ -16,5 +18,23 @@ import MongoPersistenceRoot._
     case a: Acknowledged         => new WriteConcern(1, mwc.timeout, false, false)
     case j: Journaled            => new WriteConcern(1, mwc.timeout, false, true)
     case r: ReplicasAcknowledged => new WriteConcern(2, mwc.timeout, false, false)
+  }
+
+  trait IndexesSupport {
+    mixin : ActorLogging =>
+
+    private val errorHandler: PartialFunction[Throwable, Unit] = {
+      case ex: Exception => log.info("Index creation error: {}", ex.getMessage)
+    }
+
+    def ensure(ind0: DBObject, ind1: DBObject): (MongoCollection) => Unit =
+      collection =>
+        Try(collection.ensureIndex(ind0, ind1)).recover(errorHandler)
+
+
+    def ensure(ind: DBObject): (MongoCollection) => Unit =
+      collection =>
+        Try (collection.ensureIndex(ind)).recover(errorHandler)
+
   }
 }

--- a/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/snapshot/CasbahSnapshotHelper.scala
+++ b/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/snapshot/CasbahSnapshotHelper.scala
@@ -3,17 +3,19 @@
  */
 package akka.persistence.mongo.snapshot
 
+import akka.actor.ActorLogging
 import akka.persistence.{SnapshotSelectionCriteria, SnapshotMetadata, SelectedSnapshot}
 
 import akka.persistence.serialization.Snapshot
 
-import akka.persistence.mongo.MongoPersistenceSnapshotRoot
+import akka.persistence.mongo.{IndexesSupport, MongoPersistenceSnapshotRoot}
 
 import com.mongodb.casbah.Imports._
 
 import scala.util.Try
 
-private[mongo] trait CasbahSnapshotHelper extends MongoPersistenceSnapshotRoot {
+private[mongo] trait CasbahSnapshotHelper extends MongoPersistenceSnapshotRoot with IndexesSupport {
+  mixin : ActorLogging =>
 
   val PersistenceIdKey = "persistenceId"
   val SequenceNrKey = "sequenceNr"
@@ -33,7 +35,7 @@ private[mongo] trait CasbahSnapshotHelper extends MongoPersistenceSnapshotRoot {
   private[this] val db = client(uri.database.getOrElse(throw new Exception("Cannot get database out of the mongodb URI, probably invalid format")))
   val collection = db(uri.collection.getOrElse(throw new Exception("Cannot get collection out of the mongodb URI, probably invalid format")))
 
-  collection.ensureIndex(snapIdx1, snapIdx1Options)
+  ensure(snapIdx1, snapIdx1Options)(collection)
 
   def writeJSON(metadata: SnapshotMetadata, snapshot: Any) = {
     val builder = MongoDBObject.newBuilder


### PR DESCRIPTION
When mongo becomes unavailable akka will try recreate CasbahJournal actor and this operation failed with PostRestartException. Further work in this case is impossible. I've wrapped index creation in Try block