### PR TITLE
Support for "pass-through" BSON serialization using Salat #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,22 @@ casbah-journal-mongo-journal-write-concern-timeout = 5000
 
 <br/>See the [Mongo Write Concern](#mongo-write-concern) section of this document for more information.
 
+### Plain BSON Serialization
+
+By default the plugin will use the configured akka serializer (Java Serialization, Protobuf etc.) in order to serialize the messages. If you want to serialize messages as BSON objects directly instead of a binary format, you can do so as follows:
+
+```scala
+casbah-journal.bson-serialization = "salat"
+```
+
+For the moment, only serialization using [Salat](http://github.com/novus/salat) is supported.
+
+You can also register custom BSON encoders / decoders by extending the `com.mongodb.casbah.commons.conversions.MongoConversionHelper` class and specifying its fully-qualified name in the configuration:
+
+```scala
+casbah-journal.bson-conversion-helpers = "com.application.CustomConversionHelpers"
+```
+
 ## Snapshot Configuration
 
 ### Activation

--- a/akka-persistence-mongo-casbah/build.sbt
+++ b/akka-persistence-mongo-casbah/build.sbt
@@ -22,5 +22,6 @@ resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositor
 
 libraryDependencies ++= Seq(
   "org.mongodb"         %% "casbah"                        % "2.7.4"    % "compile" pomOnly(),
+  "com.novus"           %% "salat"                         % "1.9.9"    % "compile" exclude ("org.mongodb", "casbah"),
   "com.github.krasserm" %% "akka-persistence-testkit"      % "0.3.4"    % "test"
 )

--- a/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/journal/BSONSerialization.scala
+++ b/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/journal/BSONSerialization.scala
@@ -1,0 +1,113 @@
+package akka.persistence.mongo.journal
+
+import akka.actor.{ActorSystem, ExtendedActorSystem}
+import akka.event.Logging
+import akka.persistence.Persistence
+import akka.persistence.mongo.MongoPersistenceJournalRoot
+import com.mongodb.casbah.Imports._
+import com.mongodb.casbah.commons.conversions.MongoConversionHelper
+import com.mongodb.casbah.commons.conversions.scala.{DeregisterJodaTimeConversionHelpers, RegisterJodaTimeConversionHelpers, RegisterConversionHelpers}
+import com.novus.salat.{Grater, Context}
+
+import scala.util.control.NonFatal
+
+trait BSONSerialization {
+
+  def fromBSON(doc: MongoDBObject, typeHint: String): Any
+
+  def toBSON(obj: Any): MongoDBObject
+
+}
+
+class SalatBSONSerialization(system: ExtendedActorSystem) extends BSONSerialization {
+
+  val log = Logging(system, getClass.getName)
+
+  val conversionHelpers = {
+    val ConfigPath = "casbah-journal.bson-conversion-helpers"
+
+    val helpersClass = if (system.settings.config.hasPath(ConfigPath)) {
+      val helper = system.settings.config.getString(ConfigPath)
+      log.info(s"Using custom BSON conversion helper: $helper")
+      helper
+    } else {
+      "akka.persistence.mongo.journal.DefaultConversionHelpers"
+    }
+
+    system.dynamicAccess.classLoader
+      .loadClass(helpersClass)
+      .newInstance()
+      .asInstanceOf[MongoConversionHelper]
+  }
+
+  // call these to be ready for all kind of custom types our Events may carry
+  conversionHelpers.register()
+
+  implicit val salatContext = new Context {
+    override val name = "serializer"
+    registerClassLoader(system.dynamicAccess.classLoader)
+  }
+
+  override def fromBSON(doc: MongoDBObject, typeHint: String): Any = {
+    try {
+      val grater = salatContext.lookup(typeHint)
+      grater.asObject(doc)
+    } catch { case NonFatal(t) =>
+      log.error(t, "Could not deserialize object from BSON")
+      // grater glitches are verbose, a lot of information is hidden if we don't spill it out
+      t.printStackTrace()
+      throw t
+    }
+  }
+
+  override def toBSON(obj: Any): MongoDBObject = {
+    try {
+      val grater: Grater[AnyRef] = salatContext.lookup(obj.getClass.getName).asInstanceOf[Grater[AnyRef]]
+      grater.asDBObject(obj.asInstanceOf[AnyRef])
+    } catch {
+      case NonFatal(t) =>
+        log.error(t, "Could not serialize object as BSON")
+        // grater glitches are verbose, a lot of information is hidden if we don't spill it out
+        t.printStackTrace()
+        throw t
+    }
+  }
+
+}
+
+class DefaultConversionHelpers extends MongoConversionHelper {
+
+  override def register(): Unit = {
+    RegisterConversionHelpers()
+    RegisterJodaTimeConversionHelpers()
+    super.register()
+  }
+
+  override def unregister(): Unit = {
+    DeregisterJodaTimeConversionHelpers()
+    super.unregister()
+  }
+
+}
+
+trait BSONSerializationSupport { self: MongoPersistenceJournalRoot =>
+
+  val actorSystem: ActorSystem
+
+  lazy val bsonSerialization: Option[BSONSerialization] = {
+    val ConfigPath = "casbah-journal.bson-serialization"
+    if (actorSystem.settings.config.hasPath(ConfigPath)) {
+      val extension = Persistence(actorSystem)
+      val serializer = actorSystem.settings.config.getString(ConfigPath)
+      serializer match {
+        case "salat" =>
+          Some(new SalatBSONSerialization(extension.system))
+        case other =>
+          None
+      }
+    } else {
+      None
+    }
+  }
+
+}

--- a/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/journal/CasbahRecovery.scala
+++ b/akka-persistence-mongo-casbah/src/main/scala/akka/persistence/mongo/journal/CasbahRecovery.scala
@@ -11,7 +11,7 @@ import com.mongodb.casbah.Imports._
 import scala.collection.immutable
 import scala.concurrent._
 
-trait CasbahRecovery extends AsyncRecovery { this: CasbahJournal ⇒
+trait CasbahRecovery extends AsyncRecovery with BSONSerializationSupport { this: CasbahJournal ⇒
 
   implicit lazy val replayDispatcher = context.system.dispatchers.lookup(configReplayDispatcher)
 
@@ -29,7 +29,22 @@ trait CasbahRecovery extends AsyncRecovery { this: CasbahJournal ⇒
     val collSorted = immutable.SortedMap(coll.toList.zipWithIndex.groupBy(x => x._1.as[Long](SequenceNrKey)).toSeq: _*)
     collSorted.flatMap { x =>
       if (x._2.headOption.get._2 < max) {
-        val entry = x._2.find(_._1.get(MarkerKey) == MarkerAccepted).map(_._1.as[Array[Byte]](MessageKey)).map(fromBytes[PersistentRepr])
+        val entry: Option[PersistentRepr] = x._2.find(_._1.get(MarkerKey) == MarkerAccepted).map(_._1).map {e =>
+          if (e.containsField(TypeHintKey)) {
+            val typeHint = e.as[String](TypeHintKey)
+            bsonSerialization.map { bs =>
+              val bson = e.as[MongoDBObject](MessageKey)
+              val payload = bs.fromBSON(bson, typeHint)
+              PersistentRepr(payload, e.as[Long](SequenceNrKey))
+            } getOrElse {
+              log.error(s"Persistent message with type hint $typeHint found but no BSON deserialization configured")
+              throw new IllegalStateException("Encounterd persistent message encoded as plain BSON object, but no BSON Serialization configured")
+            }
+          } else {
+            val bytes = e.as[Array[Byte]](MessageKey)
+            fromBytes[PersistentRepr](bytes)
+          }
+        }
         val deleted = x._2.exists(_._1.get(MarkerKey) == MarkerDelete)
         val confirms = x._2.filter(_._1.as[String](MarkerKey).substring(0,1) == MarkerConfirmPrefix).map(_._1.as[String](MarkerKey).substring(2)).to[immutable.Seq]
         if (entry.nonEmpty) Some(entry.get.update(deleted = deleted, confirms = confirms)) else None

--- a/akka-persistence-mongo-casbah/src/test/scala/akka/persistence/mongo/serialization/SalatSerializationSpec.scala
+++ b/akka-persistence-mongo-casbah/src/test/scala/akka/persistence/mongo/serialization/SalatSerializationSpec.scala
@@ -1,0 +1,129 @@
+package akka.persistence.mongo.serialization
+
+import java.util.Date
+
+import akka.persistence.mongo.MongoCleanup
+import com.mongodb.casbah.commons.conversions.MongoConversionHelper
+import org.bson.BSON
+import org.joda.time.{DateTime, LocalTime}
+
+import scala.concurrent.duration._
+import akka.actor._
+import akka.persistence._
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+
+import SalatSerializationSpec._
+
+import org.scalatest._
+
+object SalatSerializationSpec {
+  def config(port: Int) = ConfigFactory.parseString(
+    s"""
+      |akka.actor.serialize-messages = on
+      |casbah-journal.bson-serialization = "salat"
+      |casbah-journal.bson-conversion-helpers = "akka.persistence.mongo.serialization.CustomHelpers"
+      |akka.persistence.journal.plugin = "casbah-journal"
+      |akka.persistence.snapshot-store.plugin = "casbah-snapshot-store"
+      |akka.persistence.journal.max-deletion-batch-size = 3
+      |akka.persistence.publish-plugin-commands = on
+      |akka.persistence.publish-confirmations = on
+      |casbah-journal.mongo-journal-url = "mongodb://localhost:$port/store.messages"
+      |casbah-journal.mongo-journal-write-concern = "acknowledged"
+      |casbah-journal.mongo-journal-write-concern-timeout = 10000
+      |casbah-snapshot-store.mongo-snapshot-url = "mongodb://localhost:$port/store.snapshots"
+      |casbah-snapshot-store.mongo-snapshot-write-concern = "acknowledged"
+      |casbah-snapshot-store.mongo-snapshot-write-concern-timeout = 10000
+     """.stripMargin)
+
+  class PersistentActorTest(val persistenceId: String, testEvent: SomeEvent, replyTo: ActorRef) extends PersistentActor with ActorLogging {
+    def receiveRecover: Receive = handle
+    def receiveCommand: Receive = {
+      case "TestMe" => persist(testEvent){ replyTo ! "Persisted "+ _.toString }
+    }
+
+    def handle: Receive = {
+      case payload: SomeEvent =>
+        replyTo ! payload
+
+       case _ =>
+    }
+  }
+}
+
+class SalatSerializationSpec extends TestKit(ActorSystem("test", config(27017)))
+  with ImplicitSender
+  with WordSpecLike
+  with Matchers
+  with MongoCleanup {
+
+  override val actorSystem: ActorSystem = system
+
+  val event = SomeEvent("Arthur Dent", 42)
+  val customEvent = SomeEventWithCustomType("Ford Prefect", new LocalTime(12, 42))
+
+  "SalatBSONSerialzation" must {
+    "round trip a class" in {
+      val serializer = serialization.findSerializerFor(event)
+      val bytes = serializer.toBinary(event)
+      val rehydrated = serializer.fromBinary(bytes, event.getClass)
+      info(s"In: $event. Out: $rehydrated")
+      assert(event == rehydrated)
+    }
+    "round trip a class with custom de/serialization helpers" in {
+      val serializer = serialization.findSerializerFor(customEvent)
+      val bytes = serializer.toBinary(customEvent)
+      val rehydrated = serializer.fromBinary(bytes, customEvent.getClass)
+      info(s"In: $customEvent. Out: $rehydrated")
+      assert(customEvent == rehydrated)
+    }
+    "persist event as BSON and recover using it" in {
+      val origActorRef = system.actorOf(Props(classOf[PersistentActorTest], "Tester1", event, testActor))
+      origActorRef ! "TestMe"
+      expectMsg(5.second, s"Persisted $event")
+      val recoveredActorRef = system.actorOf(Props(classOf[PersistentActorTest], "Tester1", null, testActor))
+      expectMsg(5.seconds, event)
+    }
+  }
+
+}
+
+case class SomeEvent(a: String, b: Int)
+case class SomeEventWithCustomType(a: String, b: LocalTime)
+
+class CustomHelpers extends MongoConversionHelper {
+
+    val LocalTime = classOf[LocalTime]
+    val Date = classOf[Date]
+
+    import org.bson.Transformer
+
+    val serializer = new Transformer {
+      override def transform(o: AnyRef) = {
+        o match {
+          case l: LocalTime => l.toDateTimeToday.toDate
+          case _ => o
+        }
+      }
+    }
+    val deserializer = new Transformer {
+      override def transform(o: AnyRef) = {
+        o match {
+          case date: java.util.Date => new DateTime(date).toLocalTime
+          case _ => o
+        }
+      }
+    }
+
+  override def register(): Unit = {
+    BSON.addEncodingHook(LocalTime, serializer)
+    BSON.addDecodingHook(Date, deserializer)
+    super.register()
+  }
+
+  override def unregister(): Unit = {
+    BSON.removeEncodingHook(LocalTime, serializer)
+    BSON.removeDecodingHook(Date, deserializer)
+    super.unregister()
+  }
+}


### PR DESCRIPTION
This allows to store messages as BSON instead of a binary blob in MongoDB, which can be useful for several reasons, such as being able to perform queries on the journal in MongoDB directly.

It is possible to add custom BSON encoders / decoders if the default ones are not suffiscient.

The implementation does not make use of the default akka serialization mechanism as the aim is to store the message as BSON and the akka serialization mechanism has binary as a target format.
